### PR TITLE
CRM-2651 Remote Token store from OAuth2Services. They cannot be used consistently

### DIFF
--- a/Kronos/OAuth2Providers/Google/GoogleOAuth2Service.php
+++ b/Kronos/OAuth2Providers/Google/GoogleOAuth2Service.php
@@ -5,7 +5,7 @@ namespace Kronos\OAuth2Providers\Google;
 use Kronos\OAuth2Providers\Exceptions\InvalidRefreshTokenException;
 use Kronos\OAuth2Providers\OAuthRefreshableInterface;
 use Kronos\OAuth2Providers\OAuthServiceInterface;
-use Kronos\OAuth2Providers\Storage\AccessTokenStorageInterface;
+use League\OAuth2\Client\Grant;
 use League\OAuth2\Client\Provider\Google;
 use League\OAuth2\Client\Token\AccessToken;
 
@@ -80,9 +80,21 @@ class GoogleOAuth2Service extends Google  implements OAuthServiceInterface, OAut
 	 * @return AccessToken
 	 */
 	protected function getNewAccessTokenByRefreshToken($refresh_token){
-		return $this->getAccessToken('refresh_token', [
-			'refresh_token' => $refresh_token
-		]);
+	    $options = [];
+        $grant = new Grant\RefreshToken();
+        $params = [
+            'client_id'     => $this->clientId,
+            'client_secret' => $this->clientSecret,
+            'refresh_token' => $refresh_token
+        ];
+
+        $params   = $grant->prepareRequestParameters($params, $options);
+        $request  = $this->getAccessTokenRequest($params);
+        $response = $this->getParsedResponse($request);
+        $prepared = $this->prepareAccessTokenResponse($response);
+        $token    = $this->createAccessToken($prepared, $grant);
+
+        return $token;
 	}
 
 	/**

--- a/Kronos/OAuth2Providers/Google/GoogleOAuth2Service.php
+++ b/Kronos/OAuth2Providers/Google/GoogleOAuth2Service.php
@@ -17,19 +17,14 @@ class GoogleOAuth2Service extends Google  implements OAuthServiceInterface, OAut
 
 	protected $defaultAuthorizationUrlOptions = ['approval_prompt'=>'force'];
 
-	/**
-	 * @var AccessTokenStorageInterface
-	 */
-	private $accessTokenStore;
 
 	/**
 	 * @param string $clientId
 	 * @param string $clientSecret
 	 * @param string $redirectUri
-	 * @param AccessTokenStorageInterface $accessTokenStore
 	 * @param array $collaborators
 	 */
-	public function __construct($clientId, $clientSecret, $redirectUri, AccessTokenStorageInterface $accessTokenStore,array $collaborators = []) {
+	public function __construct($clientId, $clientSecret, $redirectUri, array $collaborators = []) {
 
 		parent::__construct([
 			'clientId'          => $clientId,
@@ -37,8 +32,6 @@ class GoogleOAuth2Service extends Google  implements OAuthServiceInterface, OAut
 			'redirectUri'       => $redirectUri,
 			'accessType'        => 'offline',
 		],$collaborators);
-
-		$this->accessTokenStore = $accessTokenStore;
 	}
 
 	/**
@@ -72,16 +65,6 @@ class GoogleOAuth2Service extends Google  implements OAuthServiceInterface, OAut
 	}
 
 	/**
-	 * @inheritdoc
-	 */
-	public function getAccessToken($grant, array $options = []){
-		$token = parent::getAccessToken($grant, $options);
-		$this->storeToken($token);
-		return $token;
-	}
-
-
-	/**
 	 * @param string $code
 	 * @param array $options Additionnal options to pass getAccessToken()
 	 * @return AccessToken
@@ -112,23 +95,8 @@ class GoogleOAuth2Service extends Google  implements OAuthServiceInterface, OAut
 			throw new InvalidRefreshTokenException($refresh_token);
 		}
 
-		$token = $this->accessTokenStore->retrieveAccessToken($refresh_token);
-		if($token) {
-			return $token;
-		}
-
-		$token = $this->getNewAccessTokenByRefreshToken($refresh_token);
-
-		return $token;
+		return $this->getNewAccessTokenByRefreshToken($refresh_token);
 	}
-
-	/**
-	 * @param AccessToken $token
-	 */
-	protected function storeToken(AccessToken $token){
-		$this->accessTokenStore->storeAccessToken($token);
-	}
-
 
 	/**
 	 * @param array $response

--- a/Kronos/OAuth2Providers/MicrosoftGraph/MicrosoftGraphOAuth2Service.php
+++ b/Kronos/OAuth2Providers/MicrosoftGraph/MicrosoftGraphOAuth2Service.php
@@ -5,7 +5,7 @@ namespace Kronos\OAuth2Providers\MicrosoftGraph;
 use Kronos\OAuth2Providers\Exceptions\InvalidRefreshTokenException;
 use Kronos\OAuth2Providers\OAuthRefreshableInterface;
 use Kronos\OAuth2Providers\OAuthServiceInterface;
-use Kronos\OAuth2Providers\Storage\AccessTokenStorageInterface;
+use League\OAuth2\Client\Grant;
 use League\OAuth2\Client\Token\AccessToken;
 
 class MicrosoftGraphOAuth2Service extends \EightyOneSquare\OAuth2\Client\Provider\MicrosoftGraph implements OAuthServiceInterface, OAuthRefreshableInterface {
@@ -58,8 +58,21 @@ class MicrosoftGraphOAuth2Service extends \EightyOneSquare\OAuth2\Client\Provide
 	 * @return AccessToken
 	 */
 	protected function getNewAccessTokenByRefreshToken($refresh_token){
-		return $this->getAccessToken('refresh_token', [
-			'refresh_token' => $refresh_token]);
+        $options = [];
+        $grant = new Grant\RefreshToken();
+        $params = [
+            'client_id'     => $this->clientId,
+            'client_secret' => $this->clientSecret,
+            'refresh_token' => $refresh_token
+        ];
+
+        $params   = $grant->prepareRequestParameters($params, $options);
+        $request  = $this->getAccessTokenRequest($params);
+        $response = $this->getParsedResponse($request);
+        $prepared = $this->prepareAccessTokenResponse($response);
+        $token    = $this->createAccessToken($prepared, $grant);
+
+        return $token;
 	}
 
 	/**

--- a/Kronos/OAuth2Providers/MicrosoftGraph/MicrosoftGraphOAuth2Service.php
+++ b/Kronos/OAuth2Providers/MicrosoftGraph/MicrosoftGraphOAuth2Service.php
@@ -11,11 +11,6 @@ use League\OAuth2\Client\Token\AccessToken;
 class MicrosoftGraphOAuth2Service extends \EightyOneSquare\OAuth2\Client\Provider\MicrosoftGraph implements OAuthServiceInterface, OAuthRefreshableInterface {
 
 	/**
-	 * @var AccessTokenStorageInterface
-	 */
-	private $accessTokenStore;
-
-	/**
 	 * @var string[]
 	 */
 	protected $defaultAuthorizationUrlOptions = ['prompt'=>'consent'];
@@ -24,18 +19,15 @@ class MicrosoftGraphOAuth2Service extends \EightyOneSquare\OAuth2\Client\Provide
 	 * @param string $clientId
 	 * @param string $clientSecret
 	 * @param string $redirectUri
-	 * @param AccessTokenStorageInterface $accessTokenStore
 	 * @param array $collaborators
 	 */
-	public function __construct($clientId, $clientSecret, $redirectUri, AccessTokenStorageInterface $accessTokenStore,array $collaborators = []) {
+	public function __construct($clientId, $clientSecret, $redirectUri, array $collaborators = []) {
 		parent::__construct([
 			'clientId'          => $clientId,
 			'clientSecret'      => $clientSecret,
 			'redirectUri'       => $redirectUri,
 			'accessType'        => 'offline',
 		],$collaborators);
-
-		$this->accessTokenStore = $accessTokenStore;
 	}
 
 	/**
@@ -50,20 +42,11 @@ class MicrosoftGraphOAuth2Service extends \EightyOneSquare\OAuth2\Client\Provide
 		);
 	}
 
-
-	/**
-	 * @inheritdoc
-	 */
-	public function getAccessToken($grant = 'authorization_code', array $options = []){
-		$token = parent::getAccessToken($grant, $options);
-		$this->storeToken($token);
-		return $token;
-	}
-
-	/**
-	 * @param string $code
-	 * @return AccessToken
-	 */
+    /**
+     * @param string $code
+     * @param array $options
+     * @return AccessToken
+     */
 	public function getAccessTokenByAuthorizationCode($code, array $options = []) {
 		return $this->getAccessToken('authorization_code', array_merge([
 			'code' => $code,
@@ -89,21 +72,7 @@ class MicrosoftGraphOAuth2Service extends \EightyOneSquare\OAuth2\Client\Provide
 			throw new InvalidRefreshTokenException($refresh_token);
 		}
 
-		$token = $this->accessTokenStore->retrieveAccessToken($refresh_token);
-		if($token) {
-			return $token;
-		}
-
-		$token = $this->getNewAccessTokenByRefreshToken($refresh_token);
-
-		return $token;
-	}
-
-	/**
-	 * @param AccessToken $token
-	 */
-	protected function storeToken(AccessToken $token){
-		$this->accessTokenStore->storeAccessToken($token);
+		return $this->getNewAccessTokenByRefreshToken($refresh_token);
 	}
 
 	/**

--- a/Kronos/OAuth2Providers/Outlook/OutlookOAuth2Service.php
+++ b/Kronos/OAuth2Providers/Outlook/OutlookOAuth2Service.php
@@ -21,26 +21,19 @@ class OutlookOAuth2Service extends Microsoft implements OAuthServiceInterface, O
 	protected $defaultAuthorizationUrlOptions = ['display'=>'popup'];
 
 	/**
-	 * @var AccessTokenStorageInterface
-	 */
-	private $accessTokenStore;
-
-	/**
 	 * @param string $clientId
 	 * @param string $clientSecret
 	 * @param string $redirectUri
 	 * @param AccessTokenStorageInterface $accessTokenStore
 	 * @param array $collaborators
 	 */
-	public function __construct($clientId, $clientSecret, $redirectUri, AccessTokenStorageInterface $accessTokenStore,array $collaborators = []) {
+	public function __construct($clientId, $clientSecret, $redirectUri, array $collaborators = []) {
 
 		parent::__construct([
 			'clientId'          => $clientId,
 			'clientSecret'      => $clientSecret,
 			'redirectUri'       => $redirectUri
 		],$collaborators);
-
-		$this->accessTokenStore = $accessTokenStore;
 	}
 
 	/**
@@ -61,16 +54,6 @@ class OutlookOAuth2Service extends Microsoft implements OAuthServiceInterface, O
 			array_merge($this->defaultAuthorizationUrlOptions,$options)
 		);
 	}
-
-	/**
-	 * @inheritdoc
-	 */
-	public function getAccessToken($grant, array $options = []){
-		$token = parent::getAccessToken($grant, $options);
-		$this->storeToken($token);
-		return $token;
-	}
-
 
 	/**
 	 * @param string $code
@@ -103,23 +86,8 @@ class OutlookOAuth2Service extends Microsoft implements OAuthServiceInterface, O
 			throw new InvalidRefreshTokenException($refresh_token);
 		}
 
-		$token = $this->accessTokenStore->retrieveAccessToken($refresh_token);
-		if($token) {
-			return $token;
-		}
-
-		$token = $this->getNewAccessTokenByRefreshToken($refresh_token);
-
-		return $token;
+		return $this->getNewAccessTokenByRefreshToken($refresh_token);
 	}
-
-	/**
-	 * @param AccessToken $token
-	 */
-	protected function storeToken(AccessToken $token){
-		$this->accessTokenStore->storeAccessToken($token);
-	}
-
 
 	/**
 	 * @return string

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
   ],
   "require": {
     "php": "^5.6",
-    "league/oauth2-client": "^2.2",
-    "league/oauth2-google":"^2.0",
+    "league/oauth2-client": "^2.3.0",
+    "league/oauth2-google":"^2.0.1",
     "kronos/oauth2-microsoft-graph": "0.1.0",
     "phpseclib/phpseclib": "^2.0",
     "firebase/php-jwt": "^4.0",


### PR DESCRIPTION
La stratégie qu'on utilisait était de mettre en cache les access token en utilisant le refresh token.

En cas de re-négociation du accessToken par refreshToken, souvent le refreshToken n'est pas retourné la la réponse. On est donc pas capable de le mettre en cache.

Aussi, dans le cas ou on demandrais pas d'accès "offline", on aurait pas de refresh token. 

Pour CRM, on a décidé de persister les accessToken en DB. 

Le tokenStore a été retiré.