### PR TITLE
Remove defaults that were too specific and various improvements

### DIFF
--- a/Kronos/OAuth2Providers/Google/GoogleProvider.php
+++ b/Kronos/OAuth2Providers/Google/GoogleProvider.php
@@ -11,18 +11,8 @@ class GoogleProvider extends Google implements StateAwareInterface
 {
     use StateServiceAwareTrait;
 
-    protected const DEFAULT_SCOPES = [
-        'https://www.googleapis.com/auth/userinfo.email',
-        'https://www.googleapis.com/auth/userinfo.profile',
-        'https://mail.google.com/',
-    ];
-
     protected const DEFAULT_OPTIONS = [
         'accessType' => 'offline',
-    ];
-
-    protected const DEFAULT_AUTH_OPTIONS = [
-        'prompt' => 'consent',
     ];
 
     public function __construct(array $options = [], array $collaborators = [])
@@ -36,20 +26,5 @@ class GoogleProvider extends Google implements StateAwareInterface
             $collaborators['stateService'] = new SessionBasedHashService();
         }
         $this->setStateService($collaborators['stateService']);
-    }
-
-    /**
-     * @return string[]
-     */
-    protected function getDefaultScopes(): array
-    {
-        return self::DEFAULT_SCOPES;
-    }
-
-    public function getAuthorizationUrl(array $options = []): string
-    {
-        return parent::getAuthorizationUrl(
-            array_merge(self::DEFAULT_AUTH_OPTIONS, $options)
-        );
     }
 }

--- a/Kronos/OAuth2Providers/Microsoft/MicrosoftProvider.php
+++ b/Kronos/OAuth2Providers/Microsoft/MicrosoftProvider.php
@@ -12,8 +12,11 @@ class MicrosoftProvider extends Azure implements StateAwareInterface
 {
     use StateServiceAwareTrait;
 
-    protected const DEFAULT_AUTH_OPTIONS = [
-        'prompt' => 'consent',
+    protected const DEFAULT_SCOPES = [
+        'openid',
+        'profile',
+        'email',
+        'offline_access',
     ];
 
     public function __construct(array $options = [], array $collaborators = [])
@@ -26,15 +29,13 @@ class MicrosoftProvider extends Azure implements StateAwareInterface
         $this->setStateService($collaborators['stateService']);
     }
 
-    public function getAuthorizationUrl(array $options = []): string
-    {
-        return parent::getAuthorizationUrl(
-            array_merge(self::DEFAULT_AUTH_OPTIONS, $options)
-        );
-    }
-
     protected function createResourceOwner(array $response, AccessToken $token): MicrosoftUser
     {
         return new MicrosoftUser($response);
+    }
+
+    protected function getDefaultScopes(): array
+    {
+        return array_merge(parent::getDefaultScopes(), self::DEFAULT_SCOPES);
     }
 }

--- a/Kronos/OAuth2Providers/Microsoft/MicrosoftProvider.php
+++ b/Kronos/OAuth2Providers/Microsoft/MicrosoftProvider.php
@@ -12,6 +12,9 @@ class MicrosoftProvider extends Azure implements StateAwareInterface
 {
     use StateServiceAwareTrait;
 
+    public const VERSION_1_0 = parent::ENDPOINT_VERSION_1_0;
+    public const VERSION_2_0 = parent::ENDPOINT_VERSION_2_0;
+
     protected const DEFAULT_SCOPES = [
         'openid',
         'profile',
@@ -21,6 +24,10 @@ class MicrosoftProvider extends Azure implements StateAwareInterface
 
     public function __construct(array $options = [], array $collaborators = [])
     {
+        if (isset($options['version'])) {
+            $options['defaultEndPointVersion'] = $options['version'];
+        }
+
         parent::__construct($options, $collaborators);
 
         if (empty($collaborators['stateService'])) {

--- a/Kronos/OAuth2Providers/OAuth2Service.php
+++ b/Kronos/OAuth2Providers/OAuth2Service.php
@@ -42,6 +42,17 @@ class OAuth2Service implements OAuthServiceInterface
         return $this->provider->getAuthorizationUrl($options);
     }
 
+    public function getState(): string
+    {
+        $state = $this->provider->getState();
+
+        if (empty($state)) {
+            throw new \RuntimeException("Tried to access state before it was generated.");
+        }
+
+        return $state;
+    }
+
     public function validateState(string $state): bool
     {
         if ($this->provider instanceof StateAwareInterface) {

--- a/Kronos/OAuth2Providers/OAuthServiceInterface.php
+++ b/Kronos/OAuth2Providers/OAuthServiceInterface.php
@@ -20,5 +20,7 @@ interface OAuthServiceInterface
 
     public function getAuthorizationUrl(array $options = []): string;
 
+    public function getState(): string;
+
     public function validateState(string $state): bool;
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # oauth2-providers
-Kronos OAuth2 providers for https://github.com/thephpleague/oauth2-client
+Equisoft OAuth2 providers for https://github.com/thephpleague/oauth2-client
+
+- Auth0
+- Google
+- Microsoft
+- OpenId
+
+### Note for the Microsoft provider
+The Microsoft provider is able to connect to both version 1 and 2 of the Identity Platform (Azure).
+To use a specific version, the provider must be instantiated with the appropriate option:
+```php
+$provider = new MicrosoftProvider([
+    'version' => MicrosoftProvider::VERSION_2_0,
+]);
+```
+
+Also, for the `email` claim to be available in the Resource Owner, the optional `email` scope must
+be included. It can be added using the `scopes` option during instanciation, or it can be part of
+the options passed during subsequent token requests
+(https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens).
+
+For additional configuration options, check the documentation of the provider:
+
+https://github.com/thenetworg/oauth2-azure

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,6 @@
       "Kronos\\Tests\\OAuth2Providers\\": "tests/Kronos/Tests/OAuth2Providers"
     }
   },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/kronostechnologies/oauth2-microsoft-graph.git"
-    }
-  ],
   "require": {
     "php": "^7.4 || ^8.1",
     "league/oauth2-client": "^2.6.1",

--- a/tests/Kronos/Tests/OAuth2Providers/Google/GoogleOAuth2ServiceTest.php
+++ b/tests/Kronos/Tests/OAuth2Providers/Google/GoogleOAuth2ServiceTest.php
@@ -61,13 +61,6 @@ class GoogleOAuth2ServiceTest extends TestCase
         $this->googleOAuth2Service = new RefreshableOAuth2Service($provider);
     }
 
-    public function test_askingForAuthorizationUrl_getAuthorizationUrl_ShouldContainsDefaultOption()
-    {
-        $url = $this->googleOAuth2Service->getAuthorizationUrl();
-
-        $this->assertStringContainsString('prompt=consent', $url);
-    }
-
     public function test_askingForAuthorizationUrl_getAuthorizationUrl_ShouldContainsStateParameterWithValidSalt()
     {
         $url = $this->googleOAuth2Service->getAuthorizationUrl();


### PR DESCRIPTION
Quelques petites améliorations:

- Ajouter une méthode `getState()` sur l'interface de Service pour accéder au state généré par le provider
- Retirer des options et des scopes par défaut qui semblaient spécifiques à un usage dans le crm
- Ajouter des nouvelles constantes pour spécifier la version du endpoint Microsoft
- Ajouter quelques explications dans le README
- Retirer une configuration inutilisée dans composer.json